### PR TITLE
Passed current search value to the onEmptyActionPressed function

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ final double? dropdownHeight;
 final TextStyle? searchTextStyle;
 final String emptyText;
 final String emptyActionText;
-final Future<void> Function()? onEmptyActionPressed;
+final Future<void> Function(String)? onEmptyActionPressed;
 final Widget? dropdownItemSeparator;
 
 ```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,7 +72,7 @@ class _MyHomePageState extends State<MyHomePage> {
               height: 16,
             ),
             DropdownFormField<Map<String, dynamic>>(
-              onEmptyActionPressed: () async {},
+              onEmptyActionPressed: (String str) async {},
               dropdownItemSeparator: Divider(
                 color: Colors.black,
                 height: 1,

--- a/lib/src/dropdown.dart
+++ b/lib/src/dropdown.dart
@@ -76,7 +76,7 @@ class DropdownFormField<T> extends StatefulWidget {
   final String emptyActionText;
 
   /// this functon triggers on click of emptyAction button
-  final Future<void> Function()? onEmptyActionPressed;
+  final Future<void> Function(String value)? onEmptyActionPressed;
 
   /// Separator between the dropdown items
   final Widget? dropdownItemSeparator;
@@ -304,7 +304,8 @@ class DropdownFormFieldState<T> extends State<DropdownFormField>
                                         TextButton(
                                           onPressed: () async {
                                             await widget
-                                                .onEmptyActionPressed!();
+                                                .onEmptyActionPressed!(_searchTextController
+                                                .value.text);
                                             _search(_searchTextController
                                                 .value.text);
                                           },


### PR DESCRIPTION
In existing implementation the function onEmptyActionPressed function doesn't receive any values. In some cases, users want to preserve what they typed in the search field on creating a new option. This was not straightforward.

We have to use filterFn to get the current search value and store it somewhere else. And get that value inside onEmptyActionPressed function. Though this works, there is some additional work needs here.

This update brings a change that this function gets a string parameter that holds the value of whatever is typed in the search field.